### PR TITLE
Add conda and build with jlpm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda/bin:$PATH
+  - export PATH=/home/travis/miniconda3/bin:$PATH
   - conda update --yes conda
   - conda create --yes -n travis python=3.7
   - conda activate travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda init bash
+  - conda init bash && source /home/travis/.bashrc
   - conda create -q -n travis python=3.7
   - conda activate travis
   - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
       install:
         - npm install mocha
         - conda install jupyterlab
+        - jlpm install
       script:
         - jlpm build
         - jlpm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       env: BUILD_LANG=node_js
       install:
         - npm install mocha
-        - conda install jupyter-lab
+        - conda install jupyterlab
       script:
         - jlpm build
         - jlpm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
+  - conda init bash
   - conda create -q -n travis python=3.7
   - conda activate travis
+  - conda info -a
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       env: BUILD_LANG=node_js
       install:
         - npm install mocha
-        - conda install jupyter-lab
+        - conda install jupyter-lab -y
       script:
         - jlpm build
         - jlpm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,33 @@
 sudo: false
+
+before_install:
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/miniconda/bin:$PATH
+  - conda update --yes conda
+  - conda create --yes -n travis python=3.7
+  - conda activate travis
+
 matrix:
   include:
     - language: python
       python: "3.7"
       env: BUILD_LANG=python
-      install: pip install pytest && pip install -e .
-      script: pytest jupyterlab_nvdashboard
+      install:
+        - pip install pytest
+        - pip install -e .
+      script:
+        - pytest jupyterlab_nvdashboard
     - language: node_js
       node_js: "10"
       env: BUILD_LANG=node_js
-      install: npm install mocha
-      script: npm test
+      install:
+        - npm install mocha
+        - conda install jupyter-lab
+      script:
+        - jlpm build
+        - jlpm test
 
 deploy:
   - provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ sudo: false
 before_install:
   - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda3/bin:$PATH
-  - conda update --yes conda
-  - conda create --yes -n travis python=3.7
+  - ./miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda create -q -n travis python=3.7
   - conda activate travis
 
 matrix:
@@ -24,7 +25,7 @@ matrix:
       env: BUILD_LANG=node_js
       install:
         - npm install mocha
-        - conda install jupyter-lab -y
+        - conda install jupyter-lab
       script:
         - jlpm build
         - jlpm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - conda init bash && source /home/travis/.bashrc
   - conda create -q -n travis python=3.7
   - conda activate travis
+  - conda config --add channels conda-forge
   - conda info -a
 
 matrix:
@@ -18,6 +19,7 @@ matrix:
       python: "3.7"
       env: BUILD_LANG=python
       install:
+        - conda install jupyter-server-proxy bokeh pynvml
         - pip install pytest
         - pip install -e .
       script:


### PR DESCRIPTION
Looks like we have to run `jlpm build` to get the typescript to compile, which means we need Jupyter Lab. Probably easiest to install with conda so adding that here.