### PR TITLE
Making "Total PCI Throughput" y-axis have a dynamic scale

### DIFF
--- a/jupyterlab_nvdashboard/apps/gpu.py
+++ b/jupyterlab_nvdashboard/apps/gpu.py
@@ -17,22 +17,25 @@ gpu_handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(ngpus)]
 
 
 def gpu(doc):
-    fig = figure(title="GPU Utilization",
-                 sizing_mode="stretch_both", x_range=[0, 100])
+    fig = figure(title="GPU Utilization", sizing_mode="stretch_both", x_range=[0, 100])
 
     def get_utilization():
-        return [pynvml.nvmlDeviceGetUtilizationRates(
-            gpu_handles[i]).gpu for i in range(ngpus)]
+        return [
+            pynvml.nvmlDeviceGetUtilizationRates(gpu_handles[i]).gpu
+            for i in range(ngpus)
+        ]
 
     gpu = get_utilization()
     y = list(range(len(gpu)))
-    # right = [l + 0.8 for l in left]
     source = ColumnDataSource({"right": y, "gpu": gpu})
-    mapper = LinearColorMapper(
-        palette=all_palettes['RdYlBu'][4], low=0, high=100)
+    mapper = LinearColorMapper(palette=all_palettes["RdYlBu"][4], low=0, high=100)
 
     fig.hbar(
-        source=source, y="right", right='gpu', height=0.8, color={"field": "gpu", "transform": mapper}
+        source=source,
+        y="right",
+        right="gpu",
+        height=0.8,
+        color={"field": "gpu", "transform": mapper},
     )
 
     fig.toolbar_location = None
@@ -47,26 +50,30 @@ def gpu(doc):
 
 
 def gpu_mem(doc):
-
     def get_mem():
-        return [pynvml.nvmlDeviceGetMemoryInfo(
-            handle).used for handle in gpu_handles]
+        return [pynvml.nvmlDeviceGetMemoryInfo(handle).used for handle in gpu_handles]
 
     def get_total():
         return pynvml.nvmlDeviceGetMemoryInfo(gpu_handles[0]).total
 
-    fig = figure(title="GPU Memory",
-                 sizing_mode="stretch_both", x_range=[0, get_total()])
+    fig = figure(
+        title="GPU Memory", sizing_mode="stretch_both", x_range=[0, get_total()]
+    )
 
     gpu = get_mem()
 
     y = list(range(len(gpu)))
     source = ColumnDataSource({"right": y, "gpu": gpu})
     mapper = LinearColorMapper(
-        palette=all_palettes['RdYlBu'][8], low=0, high=get_total())
+        palette=all_palettes["RdYlBu"][8], low=0, high=get_total()
+    )
 
     fig.hbar(
-        source=source, y="right", right='gpu', height=0.8, color={"field": "gpu", "transform": mapper}
+        source=source,
+        y="right",
+        right="gpu",
+        height=0.8,
+        color={"field": "gpu", "transform": mapper},
     )
     fig.xaxis[0].formatter = NumeralTickFormatter(format="0.0 b")
     fig.xaxis.major_label_orientation = -math.pi / 12
@@ -86,45 +93,78 @@ def gpu_mem(doc):
 
 def pci(doc):
 
-    tx_fig = figure(title="TX Bytes [MB/s]",
-                    sizing_mode="stretch_both", y_range=[0, 5000])
-    pci_tx = [pynvml.nvmlDeviceGetPcieThroughput(
-        gpu_handles[i], pynvml.NVML_PCIE_UTIL_TX_BYTES)/1024 for i in range(ngpus)]
+    max_rxtx_tp = 8000
+    tx_fig = figure(
+        title="TX Bytes [/s]", sizing_mode="stretch_both", y_range=[0, max_rxtx_tp]
+    )
+    pci_tx = [
+        pynvml.nvmlDeviceGetPcieThroughput(
+            gpu_handles[i], pynvml.NVML_PCIE_UTIL_TX_BYTES
+        )
+        / 1024
+        for i in range(ngpus)
+    ]
     left = list(range(len(pci_tx)))
     right = [l + 0.8 for l in left]
     source = ColumnDataSource({"left": left, "right": right, "pci-tx": pci_tx})
     mapper = LinearColorMapper(
-        palette=all_palettes['RdYlBu'][4], low=0, high=5000)
-
-    tx_fig.quad(
-        source=source, left="left", right="right", bottom=0, top="pci-tx", color={"field": "pci-tx", "transform": mapper}
+        palette=all_palettes["RdYlBu"][4], low=0, high=max_rxtx_tp
     )
 
-    rx_fig = figure(title="RX Bytes [MB/s]",
-                    sizing_mode="stretch_both", y_range=[0, 5000])
-    pci_rx = [pynvml.nvmlDeviceGetPcieThroughput(
-        gpu_handles[i], pynvml.NVML_PCIE_UTIL_RX_BYTES)/1024 for i in range(ngpus)]
+    tx_fig.quad(
+        source=source,
+        left="left",
+        right="right",
+        bottom=0,
+        top="pci-tx",
+        color={"field": "pci-tx", "transform": mapper},
+    )
+
+    rx_fig = figure(
+        title="RX Bytes [/s]", sizing_mode="stretch_both", y_range=[0, max_rxtx_tp]
+    )
+    pci_rx = [
+        pynvml.nvmlDeviceGetPcieThroughput(
+            gpu_handles[i], pynvml.NVML_PCIE_UTIL_RX_BYTES
+        )
+        / 1024
+        for i in range(ngpus)
+    ]
     left = list(range(len(pci_rx)))
     right = [l + 0.8 for l in left]
     source = ColumnDataSource({"left": left, "right": right, "pci-rx": pci_rx})
     mapper = LinearColorMapper(
-        palette=all_palettes['RdYlBu'][4], low=0, high=5000)
+        palette=all_palettes["RdYlBu"][4], low=0, high=max_rxtx_tp
+    )
 
     rx_fig.quad(
-        source=source, left="left", right="right", bottom=0, top="pci-rx", color={"field": "pci-rx", "transform": mapper}
+        source=source,
+        left="left",
+        right="right",
+        bottom=0,
+        top="pci-rx",
+        color={"field": "pci-rx", "transform": mapper},
     )
 
     doc.title = "PCI Throughput"
-    doc.add_root(
-        column(tx_fig, rx_fig, sizing_mode="stretch_both")
-    )
+    doc.add_root(column(tx_fig, rx_fig, sizing_mode="stretch_both"))
 
     def cb():
         src_dict = {}
-        src_dict["pci-tx"] = [pynvml.nvmlDeviceGetPcieThroughput(
-            gpu_handles[i], pynvml.NVML_PCIE_UTIL_TX_BYTES)/1024 for i in range(ngpus)]
-        src_dict["pci-rx"] = [pynvml.nvmlDeviceGetPcieThroughput(
-            gpu_handles[i], pynvml.NVML_PCIE_UTIL_RX_BYTES)/1024 for i in range(ngpus)]
+        src_dict["pci-tx"] = [
+            pynvml.nvmlDeviceGetPcieThroughput(
+                gpu_handles[i], pynvml.NVML_PCIE_UTIL_TX_BYTES
+            )
+            / 1024
+            for i in range(ngpus)
+        ]
+        src_dict["pci-rx"] = [
+            pynvml.nvmlDeviceGetPcieThroughput(
+                gpu_handles[i], pynvml.NVML_PCIE_UTIL_RX_BYTES
+            )
+            / 1024
+            for i in range(ngpus)
+        ]
         source.data.update(src_dict)
 
     doc.add_periodic_callback(cb, 200)
@@ -132,27 +172,43 @@ def pci(doc):
 
 def gpu_resource_timeline(doc):
 
-    memory_list = [pynvml.nvmlDeviceGetMemoryInfo(
-        handle).total / (1024*1024) for handle in gpu_handles]
-    gpu_mem_max = max(memory_list) * (1024*1024)
+    memory_list = [
+        pynvml.nvmlDeviceGetMemoryInfo(handle).total / (1024 * 1024)
+        for handle in gpu_handles
+    ]
+    gpu_mem_max = max(memory_list) * (1024 * 1024)
     gpu_mem_sum = sum(memory_list)
 
     # Shared X Range for all plots
     x_range = DataRange1d(follow="end", follow_interval=20000, range_padding=0)
-    y_range = DataRange1d(follow="end", follow_interval=20000, range_padding=0)
     tools = "reset,xpan,xwheel_zoom"
 
-    item_dict = {"time": [], "gpu-total": [], "memory-total": [],
-                 "rx-total": [], "tx-total": []}
+    item_dict = {
+        "time": [],
+        "gpu-total": [],
+        "memory-total": [],
+        "rx-total": [],
+        "tx-total": [],
+    }
     for i in range(ngpus):
-        item_dict["gpu-"+str(i)] = []
-        item_dict["memory-"+str(i)] = []
+        item_dict["gpu-" + str(i)] = []
+        item_dict["memory-" + str(i)] = []
 
     source = ColumnDataSource(item_dict)
 
     def _get_color(ind):
-        color_list = ["blue", "red", "green", "black", "brown", "cyan",
-                      "orange", "pink", "purple", "gold"]
+        color_list = [
+            "blue",
+            "red",
+            "green",
+            "black",
+            "brown",
+            "cyan",
+            "orange",
+            "pink",
+            "purple",
+            "gold",
+        ]
         return color_list[ind % len(color_list)]
 
     memory_fig = figure(
@@ -164,10 +220,10 @@ def gpu_resource_timeline(doc):
         tools=tools,
     )
     for i in range(ngpus):
-        memory_fig.line(source=source, x="time", y="memory-" +
-                        str(i), color=_get_color(i))  # , legend="GPU-"+str(i))
+        memory_fig.line(
+            source=source, x="time", y="memory-" + str(i), color=_get_color(i)
+        )
     memory_fig.yaxis.formatter = NumeralTickFormatter(format="0.0b")
-    #memory_fig.legend.location = "top_left"
 
     gpu_fig = figure(
         title="GPU Utilization (per Device) [%]",
@@ -178,9 +234,7 @@ def gpu_resource_timeline(doc):
         tools=tools,
     )
     for i in range(ngpus):
-        gpu_fig.line(source=source, x="time", y="gpu-"+str(i),
-                     color=_get_color(i))  # , legend="GPU-"+str(i))
-    #gpu_fig.legend.location = "top_left"
+        gpu_fig.line(source=source, x="time", y="gpu-" + str(i), color=_get_color(i))
 
     tot_fig = figure(
         title="Total Utilization [%]",
@@ -190,30 +244,29 @@ def gpu_resource_timeline(doc):
         x_range=x_range,
         tools=tools,
     )
-    tot_fig.line(source=source, x="time", y="gpu-total",
-                 color="blue", legend="Total-GPU")
-    tot_fig.line(source=source, x="time", y="memory-total",
-                 color="red", legend="Total-Memory")
+    tot_fig.line(
+        source=source, x="time", y="gpu-total", color="blue", legend="Total-GPU"
+    )
+    tot_fig.line(
+        source=source, x="time", y="memory-total", color="red", legend="Total-Memory"
+    )
     tot_fig.legend.location = "top_left"
 
     pci_fig = figure(
-        title="Total PCI Throughput [MB/s]",
+        title="Total PCI Throughput [/s]",
         sizing_mode="stretch_both",
         x_axis_type="datetime",
-        y_range=[0, 10000],
         x_range=x_range,
         tools=tools,
     )
-    pci_fig.line(source=source, x="time", y="tx-total",
-                 color="blue", legend="TX")
-    pci_fig.line(source=source, x="time", y="rx-total",
-                 color="red", legend="RX")
+    pci_fig.line(source=source, x="time", y="tx-total", color="blue", legend="TX")
+    pci_fig.line(source=source, x="time", y="rx-total", color="red", legend="RX")
+    pci_fig.yaxis.formatter = NumeralTickFormatter(format="0.0b")
     pci_fig.legend.location = "top_left"
 
     doc.title = "Resource Timeline"
     doc.add_root(
-        column(gpu_fig, memory_fig, tot_fig,
-               pci_fig, sizing_mode="stretch_both")
+        column(gpu_fig, memory_fig, tot_fig, pci_fig, sizing_mode="stretch_both")
     )
 
     last_time = time.time()
@@ -229,25 +282,30 @@ def gpu_resource_timeline(doc):
         for i in range(ngpus):
             gpu = pynvml.nvmlDeviceGetUtilizationRates(gpu_handles[i]).gpu
             mem = pynvml.nvmlDeviceGetMemoryInfo(gpu_handles[i]).used
-            tx = pynvml.nvmlDeviceGetPcieThroughput(
-                gpu_handles[i], pynvml.NVML_PCIE_UTIL_TX_BYTES)/1024
-            rx = pynvml.nvmlDeviceGetPcieThroughput(
-                gpu_handles[i], pynvml.NVML_PCIE_UTIL_RX_BYTES)/1024
+            tx = (
+                pynvml.nvmlDeviceGetPcieThroughput(
+                    gpu_handles[i], pynvml.NVML_PCIE_UTIL_TX_BYTES
+                )
+                * 1024
+            )
+            rx = (
+                pynvml.nvmlDeviceGetPcieThroughput(
+                    gpu_handles[i], pynvml.NVML_PCIE_UTIL_RX_BYTES
+                )
+                * 1024
+            )
             gpu_tot += gpu
-            mem_tot += mem / (1024*1024)
+            mem_tot += mem / (1024 * 1024)
             rx_tot += rx
             tx_tot += tx
-            src_dict["gpu-"+str(i)] = [gpu]
-            src_dict["memory-"+str(i)] = [mem]
+            src_dict["gpu-" + str(i)] = [gpu]
+            src_dict["memory-" + str(i)] = [mem]
         src_dict["gpu-total"] = [gpu_tot / ngpus]
-        src_dict["memory-total"] = [(mem_tot/gpu_mem_sum)*100]
+        src_dict["memory-total"] = [(mem_tot / gpu_mem_sum) * 100]
         src_dict["tx-total"] = [tx_tot]
         src_dict["rx-total"] = [rx_tot]
 
-        source.stream(
-            src_dict,
-            1000,
-        )
+        source.stream(src_dict, 1000)
 
         last_time = now
 

--- a/jupyterlab_nvdashboard/apps/gpu.py
+++ b/jupyterlab_nvdashboard/apps/gpu.py
@@ -93,7 +93,20 @@ def gpu_mem(doc):
 
 def pci(doc):
 
-    max_rxtx_tp = 8000
+    pci_gen = pynvml.nvmlDeviceGetMaxPcieLinkGeneration(gpu_handles[0])
+    pci_width = pynvml.nvmlDeviceGetMaxPcieLinkWidth(gpu_handles[0])
+    if pci_gen == 1:
+        max_rxtx_tp = (pci_width * 250.0) / 2.0
+    elif pci_gen == 2:
+        max_rxtx_tp = (pci_width * 500.0) / 2.0
+    elif pci_gen == 3:
+        max_rxtx_tp = (pci_width * 985.0) / 2.0
+    elif pci_gen == 4:
+        max_rxtx_tp = (pci_width * 2048.0) / 2.0
+    elif pci_gen == 5:
+        max_rxtx_tp = (pci_width * 4032.0) / 2.0
+    else:
+        max_rxtx_tp = (pci_width * 8192.0) / 2.0
     tx_fig = figure(
         title="TX Bytes [MB/s]", sizing_mode="stretch_both", y_range=[0, max_rxtx_tp]
     )

--- a/jupyterlab_nvdashboard/apps/gpu.py
+++ b/jupyterlab_nvdashboard/apps/gpu.py
@@ -97,15 +97,16 @@ def pci(doc):
     pci_gen = pynvml.nvmlDeviceGetMaxPcieLinkGeneration(gpu_handles[0])
     pci_width = pynvml.nvmlDeviceGetMaxPcieLinkWidth(gpu_handles[0])
     pci_bw = {
-        # PCIe-Generation: (BW-per-lane / Width / 2-directions)
-        # [TODO: The specific numbers need to be validated]
-        1: (250.0 / 1024.0 / 2.0),
-        2: (500.0 / 1024.0 / 2.0),
-        3: (985.0 / 1024.0 / 2.0),
-        4: (2048.0 / 1024.0 / 2.0),
-        5: (4032.0 / 1024.0 / 2.0),
-        6: (8192.0 / 1024.0 / 2.0),
+        # Keys = PCIe-Generation, Values = Max PCIe Lane BW (per direction)
+        # [Note: Using specs at https://en.wikipedia.org/wiki/PCI_Express]
+        1: (250.0 / 1024.0),
+        2: (500.0 / 1024.0),
+        3: (985.0 / 1024.0),
+        4: (1969.0 / 1024.0),
+        5: (3938.0 / 1024.0),
+        6: (7877.0 / 1024.0),
     }
+    # Max PCIe Throughput = (BW-per-lane / Width)
     max_rxtx_tp = pci_width * pci_bw[pci_gen]
 
     pci_tx = [
@@ -266,7 +267,7 @@ def gpu_resource_timeline(doc):
     tot_fig.legend.location = "top_left"
 
     pci_fig = figure(
-        title="Total PCI Throughput [/s]",
+        title="Total PCI Throughput [B/s]",
         sizing_mode="stretch_both",
         x_axis_type="datetime",
         x_range=x_range,

--- a/jupyterlab_nvdashboard/apps/gpu.py
+++ b/jupyterlab_nvdashboard/apps/gpu.py
@@ -95,7 +95,7 @@ def pci(doc):
 
     max_rxtx_tp = 8000
     tx_fig = figure(
-        title="TX Bytes [/s]", sizing_mode="stretch_both", y_range=[0, max_rxtx_tp]
+        title="TX Bytes [MB/s]", sizing_mode="stretch_both", y_range=[0, max_rxtx_tp]
     )
     pci_tx = [
         pynvml.nvmlDeviceGetPcieThroughput(
@@ -121,7 +121,7 @@ def pci(doc):
     )
 
     rx_fig = figure(
-        title="RX Bytes [/s]", sizing_mode="stretch_both", y_range=[0, max_rxtx_tp]
+        title="RX Bytes [MB/s]", sizing_mode="stretch_both", y_range=[0, max_rxtx_tp]
     )
     pci_rx = [
         pynvml.nvmlDeviceGetPcieThroughput(


### PR DESCRIPTION
This PR applies black formatting to `jupyterlab_nvdashboard/apps/gpu.py`, and addresses [issue #7](https://github.com/jacobtomlinson/jupyterlab-nvdashboard/issues/7).  That is, the "Total PCI Throughput" plot for the "GPU Resources" dashboard now has a dynamic y-axis scale.

While addressing this issue, I also noticed that the stand-alone "PCI Throughput" dashboard had the maximum set to 5000 MB/s.  I tried making this scale dynamic as well, but didn't like the way it looked.  I will probably raise a new issue to discuss the best way to deal with this.