### PR TITLE
Adding NVLink dashboards

### DIFF
--- a/jupyterlab_nvdashboard/apps/gpu.py
+++ b/jupyterlab_nvdashboard/apps/gpu.py
@@ -96,32 +96,31 @@ def pci(doc):
     # Use device-0 to get "upper bound"
     pci_gen = pynvml.nvmlDeviceGetMaxPcieLinkGeneration(gpu_handles[0])
     pci_width = pynvml.nvmlDeviceGetMaxPcieLinkWidth(gpu_handles[0])
+    MB = 1024.0 * 1024.0
     pci_bw = {
         # Keys = PCIe-Generation, Values = Max PCIe Lane BW (per direction)
         # [Note: Using specs at https://en.wikipedia.org/wiki/PCI_Express]
-        1: (250.0 / 1024.0),
-        2: (500.0 / 1024.0),
-        3: (985.0 / 1024.0),
-        4: (1969.0 / 1024.0),
-        5: (3938.0 / 1024.0),
-        6: (7877.0 / 1024.0),
+        1: (250.0 * MB),
+        2: (500.0 * MB),
+        3: (985.0 * MB),
+        4: (1969.0 * MB),
+        5: (3938.0 * MB),
+        6: (7877.0 * MB),
     }
-    # Max PCIe Throughput = (BW-per-lane / Width)
+    # Max PCIe Throughput = BW-per-lane * Width
     max_rxtx_tp = pci_width * pci_bw[pci_gen]
 
     pci_tx = [
         pynvml.nvmlDeviceGetPcieThroughput(
             gpu_handles[i], pynvml.NVML_PCIE_UTIL_TX_BYTES
-        )
-        / (1024.0 * 1024.0)  # Convert KB/s -> GB/s
+        ) * 1024.0
         for i in range(ngpus)
     ]
 
     pci_rx = [
         pynvml.nvmlDeviceGetPcieThroughput(
             gpu_handles[i], pynvml.NVML_PCIE_UTIL_RX_BYTES
-        )
-        / (1024.0 * 1024.0)  # Convert KB/s -> GB/s
+        ) * 1024.0
         for i in range(ngpus)
     ]
 
@@ -135,7 +134,7 @@ def pci(doc):
     )
 
     tx_fig = figure(
-        title="TX Bytes [GB/s]", sizing_mode="stretch_both", y_range=[0, max_rxtx_tp]
+        title="TX PCIe [B/s]", sizing_mode="stretch_both", y_range=[0, max_rxtx_tp]
     )
     tx_fig.quad(
         source=source,
@@ -145,10 +144,11 @@ def pci(doc):
         top="pci-tx",
         color={"field": "pci-tx", "transform": mapper},
     )
+    tx_fig.yaxis.formatter = NumeralTickFormatter(format="0.0 b")
     tx_fig.toolbar_location = None
 
     rx_fig = figure(
-        title="RX Bytes [GB/s]", sizing_mode="stretch_both", y_range=[0, max_rxtx_tp]
+        title="RX PCIe [B/s]", sizing_mode="stretch_both", y_range=[0, max_rxtx_tp]
     )
     rx_fig.quad(
         source=source,
@@ -158,9 +158,10 @@ def pci(doc):
         top="pci-rx",
         color={"field": "pci-rx", "transform": mapper},
     )
+    rx_fig.yaxis.formatter = NumeralTickFormatter(format="0.0 b")
     rx_fig.toolbar_location = None
 
-    doc.title = "PCI Throughput"
+    doc.title = "PCIe Throughput"
     doc.add_root(column(tx_fig, rx_fig, sizing_mode="stretch_both"))
 
     def cb():
@@ -168,18 +169,285 @@ def pci(doc):
         src_dict["pci-tx"] = [
             pynvml.nvmlDeviceGetPcieThroughput(
                 gpu_handles[i], pynvml.NVML_PCIE_UTIL_TX_BYTES
-            )
-            / (1024.0 * 1024.0)  # Convert KB/s -> GB/s
+            ) * 1024.0
             for i in range(ngpus)
         ]
         src_dict["pci-rx"] = [
             pynvml.nvmlDeviceGetPcieThroughput(
                 gpu_handles[i], pynvml.NVML_PCIE_UTIL_RX_BYTES
-            )
-            / (1024.0 * 1024.0)  # Convert KB/s -> GB/s
+            ) * 1024.0
             for i in range(ngpus)
         ]
         source.data.update(src_dict)
+
+    doc.add_periodic_callback(cb, 200)
+
+
+def nvlink(doc):
+
+    import subprocess as sp
+
+    # Use device-0/link-0 to get "upper bound"
+    counter = 1
+    nlinks = pynvml.NVML_NVLINK_MAX_LINKS
+    nvlink_ver = pynvml.nvmlDeviceGetNvLinkVersion(gpu_handles[0], 0)
+    GB = 1024.0 * 1024.0 * 1024.0
+    nvlink_link_bw = {
+        # Keys = NVLink Version, Values = Max Link BW (per direction)
+        # [Note: Using specs at https://en.wikichip.org/wiki/nvidia/nvlink]
+        1: 20.0 * GB,  # GB/s
+        2: 25.0 * GB,  # GB/s
+    }
+    # Max NVLink Throughput = BW-per-link * nlinks
+    max_bw = nlinks * nvlink_link_bw.get(nvlink_ver, 25.0 * GB)
+
+    # nvmlDeviceSetNvLinkUtilizationControl seems limited, using smi:
+    sp.call(
+        [
+            "nvidia-smi",
+            "nvlink",
+            "--setcontrol",
+            str(counter) + "bz",  # Get output in bytes
+        ]
+    )
+
+    tx_fig = figure(
+        title="TX NVLink [B/s]", sizing_mode="stretch_both", y_range=[0, max_bw]
+    )
+    tx_fig.yaxis.formatter = NumeralTickFormatter(format="0.0 b")
+    nvlink_state = {}
+    nvlink_state["tx"] = [
+        sum(
+            [
+                pynvml.nvmlDeviceGetNvLinkUtilizationCounter(
+                    gpu_handles[i], j, counter
+                )["tx"]
+                for j in range(nlinks)
+            ]
+        )
+        for i in range(ngpus)
+    ]
+    nvlink_state["tx-ref"] = nvlink_state["tx"].copy()
+    left = list(range(ngpus))
+    right = [l + 0.8 for l in left]
+    source = ColumnDataSource(
+        {
+            "left": left,
+            "right": right,
+            "count-tx": [0.0 for i in range(ngpus)],
+            "count-rx": [0.0 for i in range(ngpus)],
+        }
+    )
+    mapper = LinearColorMapper(palette=all_palettes["RdYlBu"][4], low=0, high=max_bw)
+
+    tx_fig.quad(
+        source=source,
+        left="left",
+        right="right",
+        bottom=0,
+        top="count-tx",
+        color={"field": "count-tx", "transform": mapper},
+    )
+    tx_fig.toolbar_location = None
+
+    rx_fig = figure(
+        title="RX NVLink [B/s]", sizing_mode="stretch_both", y_range=[0, max_bw]
+    )
+    rx_fig.yaxis.formatter = NumeralTickFormatter(format="0.0 b")
+    nvlink_state["rx"] = [
+        sum(
+            [
+                pynvml.nvmlDeviceGetNvLinkUtilizationCounter(
+                    gpu_handles[i], j, counter
+                )["rx"]
+                for j in range(nlinks)
+            ]
+        )
+        for i in range(ngpus)
+    ]
+    nvlink_state["rx-ref"] = nvlink_state["rx"].copy()
+
+    rx_fig.quad(
+        source=source,
+        left="left",
+        right="right",
+        bottom=0,
+        top="count-rx",
+        color={"field": "count-rx", "transform": mapper},
+    )
+    rx_fig.toolbar_location = None
+
+    doc.title = "NVLink Utilization Counters"
+    doc.add_root(column(tx_fig, rx_fig, sizing_mode="stretch_both"))
+
+    def cb():
+        nvlink_state["tx-ref"] = nvlink_state["tx"].copy()
+        nvlink_state["rx-ref"] = nvlink_state["rx"].copy()
+        src_dict = {}
+        nvlink_state["tx"] = [
+            sum(
+                [
+                    pynvml.nvmlDeviceGetNvLinkUtilizationCounter(
+                        gpu_handles[i], j, counter
+                    )["tx"]
+                    for j in range(nlinks)
+                ]
+            )
+            for i in range(ngpus)
+        ]
+        nvlink_state["rx"] = [
+            sum(
+                [
+                    pynvml.nvmlDeviceGetNvLinkUtilizationCounter(
+                        gpu_handles[i], j, counter
+                    )["rx"]
+                    for j in range(nlinks)
+                ]
+            )
+            for i in range(ngpus)
+        ]
+        src_dict["count-tx"] = [
+            max(a - b, 0.) * 5.0 for (a, b) in zip(nvlink_state["tx"], nvlink_state["tx-ref"])
+        ]
+        src_dict["count-rx"] = [
+            max(a - b, 0.) * 5.0 for (a, b) in zip(nvlink_state["rx"], nvlink_state["rx-ref"])
+        ]
+
+        source.data.update(src_dict)
+
+    doc.add_periodic_callback(cb, 200)
+
+
+def nvlink_timeline(doc):
+
+    # X Range
+    x_range = DataRange1d(follow="end", follow_interval=20000, range_padding=0)
+    tools = "reset,xpan,xwheel_zoom"
+
+    item_dict = {"time": []}
+    for i in range(ngpus):
+        item_dict["nvlink-tx-" + str(i)] = []
+        item_dict["nvlink-rx-" + str(i)] = []
+
+    source = ColumnDataSource(item_dict)
+
+    def _get_color(ind):
+        color_list = [
+            "blue",
+            "red",
+            "green",
+            "black",
+            "brown",
+            "cyan",
+            "orange",
+            "pink",
+            "purple",
+            "gold",
+        ]
+        return color_list[ind % len(color_list)]
+
+    tx_fig = figure(
+        title="TX NVLink (per Device) [B/s]",
+        sizing_mode="stretch_both",
+        x_axis_type="datetime",
+        x_range=x_range,
+        tools=tools,
+    )
+    rx_fig = figure(
+        title="RX NVLink (per Device) [B/s]",
+        sizing_mode="stretch_both",
+        x_axis_type="datetime",
+        x_range=x_range,
+        tools=tools,
+    )
+    for i in range(ngpus):
+        tx_fig.line(
+            source=source, x="time", y="nvlink-tx-" + str(i), color=_get_color(i)
+        )
+        rx_fig.line(
+            source=source, x="time", y="nvlink-rx-" + str(i), color=_get_color(i)
+        )
+    tx_fig.yaxis.formatter = NumeralTickFormatter(format="0.0 b")
+    rx_fig.yaxis.formatter = NumeralTickFormatter(format="0.0 b")
+
+    doc.title = "NVLink Throughput Timeline"
+    doc.add_root(
+        column(tx_fig, rx_fig, sizing_mode="stretch_both")
+    )
+
+    counter = 1
+    nlinks = pynvml.NVML_NVLINK_MAX_LINKS
+    nvlink_state = {}
+    nvlink_state["tx"] = [
+        sum(
+            [
+                pynvml.nvmlDeviceGetNvLinkUtilizationCounter(
+                    gpu_handles[i], j, counter
+                )["tx"]
+                for j in range(nlinks)
+            ]
+        )
+        for i in range(ngpus)
+    ]
+    nvlink_state["rx"] = [
+        sum(
+            [
+                pynvml.nvmlDeviceGetNvLinkUtilizationCounter(
+                    gpu_handles[i], j, counter
+                )["rx"]
+                for j in range(nlinks)
+            ]
+        )
+        for i in range(ngpus)
+    ]
+    nvlink_state["tx-ref"] = nvlink_state["tx"].copy()
+    nvlink_state["rx-ref"] = nvlink_state["rx"].copy()
+
+    last_time = time.time()
+
+    def cb():
+        nonlocal last_time
+        nonlocal nvlink_state
+        now = time.time()
+        src_dict = {"time": [now * 1000]}
+
+        nvlink_state["tx-ref"] = nvlink_state["tx"].copy()
+        nvlink_state["rx-ref"] = nvlink_state["rx"].copy()
+        nvlink_state["tx"] = [
+            sum(
+                [
+                    pynvml.nvmlDeviceGetNvLinkUtilizationCounter(
+                        gpu_handles[i], j, counter
+                    )["tx"]
+                    for j in range(nlinks)
+                ]
+            )
+            for i in range(ngpus)
+        ]
+        nvlink_state["rx"] = [
+            sum(
+                [
+                    pynvml.nvmlDeviceGetNvLinkUtilizationCounter(
+                        gpu_handles[i], j, counter
+                    )["rx"]
+                    for j in range(nlinks)
+                ]
+            )
+            for i in range(ngpus)
+        ]
+        tx_diff = [
+            max(a - b, 0.) * 5.0 for (a, b) in zip(nvlink_state["tx"], nvlink_state["tx-ref"])
+        ]
+
+        rx_diff = [
+            max(a - b, 0.) * 5.0 for (a, b) in zip(nvlink_state["rx"], nvlink_state["rx-ref"])
+        ]
+
+        for i in range(ngpus):
+            src_dict["nvlink-tx-" + str(i)] = [tx_diff[i]]
+            src_dict["nvlink-rx-" + str(i)] = [rx_diff[i]]
+        source.stream(src_dict, 1000)
+        last_time = now
 
     doc.add_periodic_callback(cb, 200)
 
@@ -226,7 +494,7 @@ def gpu_resource_timeline(doc):
         return color_list[ind % len(color_list)]
 
     memory_fig = figure(
-        title="Memory Utilization (per Device)",
+        title="Memory Utilization (per Device) [B]",
         sizing_mode="stretch_both",
         x_axis_type="datetime",
         y_range=[0, gpu_mem_max],
@@ -237,7 +505,7 @@ def gpu_resource_timeline(doc):
         memory_fig.line(
             source=source, x="time", y="memory-" + str(i), color=_get_color(i)
         )
-    memory_fig.yaxis.formatter = NumeralTickFormatter(format="0.0b")
+    memory_fig.yaxis.formatter = NumeralTickFormatter(format="0.0 b")
 
     gpu_fig = figure(
         title="GPU Utilization (per Device) [%]",
@@ -275,7 +543,7 @@ def gpu_resource_timeline(doc):
     )
     pci_fig.line(source=source, x="time", y="tx-total", color="blue", legend="TX")
     pci_fig.line(source=source, x="time", y="rx-total", color="red", legend="RX")
-    pci_fig.yaxis.formatter = NumeralTickFormatter(format="0.0b")
+    pci_fig.yaxis.formatter = NumeralTickFormatter(format="0.0 b")
     pci_fig.legend.location = "top_left"
 
     doc.title = "Resource Timeline"

--- a/jupyterlab_nvdashboard/apps/gpu.py
+++ b/jupyterlab_nvdashboard/apps/gpu.py
@@ -11,6 +11,9 @@ import pynvml
 
 from jupyterlab_nvdashboard.utils import format_bytes
 
+KB = 1e3
+MB = KB * KB
+GB = MB * KB
 pynvml.nvmlInit()
 ngpus = pynvml.nvmlDeviceGetCount()
 gpu_handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(ngpus)]
@@ -96,7 +99,6 @@ def pci(doc):
     # Use device-0 to get "upper bound"
     pci_gen = pynvml.nvmlDeviceGetMaxPcieLinkGeneration(gpu_handles[0])
     pci_width = pynvml.nvmlDeviceGetMaxPcieLinkWidth(gpu_handles[0])
-    MB = 1024.0 * 1024.0
     pci_bw = {
         # Keys = PCIe-Generation, Values = Max PCIe Lane BW (per direction)
         # [Note: Using specs at https://en.wikipedia.org/wiki/PCI_Express]
@@ -114,7 +116,7 @@ def pci(doc):
         pynvml.nvmlDeviceGetPcieThroughput(
             gpu_handles[i], pynvml.NVML_PCIE_UTIL_TX_BYTES
         )
-        * 1024.0
+        * KB
         for i in range(ngpus)
     ]
 
@@ -122,7 +124,7 @@ def pci(doc):
         pynvml.nvmlDeviceGetPcieThroughput(
             gpu_handles[i], pynvml.NVML_PCIE_UTIL_RX_BYTES
         )
-        * 1024.0
+        * KB
         for i in range(ngpus)
     ]
 
@@ -172,14 +174,14 @@ def pci(doc):
             pynvml.nvmlDeviceGetPcieThroughput(
                 gpu_handles[i], pynvml.NVML_PCIE_UTIL_TX_BYTES
             )
-            * 1024.0
+            * KB
             for i in range(ngpus)
         ]
         src_dict["pci-rx"] = [
             pynvml.nvmlDeviceGetPcieThroughput(
                 gpu_handles[i], pynvml.NVML_PCIE_UTIL_RX_BYTES
             )
-            * 1024.0
+            * KB
             for i in range(ngpus)
         ]
         source.data.update(src_dict)
@@ -195,7 +197,6 @@ def nvlink(doc):
     counter = 1
     nlinks = pynvml.NVML_NVLINK_MAX_LINKS
     nvlink_ver = pynvml.nvmlDeviceGetNvLinkVersion(gpu_handles[0], 0)
-    GB = 1024.0 * 1024.0 * 1024.0
     nvlink_link_bw = {
         # Keys = NVLink Version, Values = Max Link BW (per direction)
         # [Note: Using specs at https://en.wikichip.org/wiki/nvidia/nvlink]

--- a/jupyterlab_nvdashboard/apps/gpu.py
+++ b/jupyterlab_nvdashboard/apps/gpu.py
@@ -113,14 +113,16 @@ def pci(doc):
     pci_tx = [
         pynvml.nvmlDeviceGetPcieThroughput(
             gpu_handles[i], pynvml.NVML_PCIE_UTIL_TX_BYTES
-        ) * 1024.0
+        )
+        * 1024.0
         for i in range(ngpus)
     ]
 
     pci_rx = [
         pynvml.nvmlDeviceGetPcieThroughput(
             gpu_handles[i], pynvml.NVML_PCIE_UTIL_RX_BYTES
-        ) * 1024.0
+        )
+        * 1024.0
         for i in range(ngpus)
     ]
 
@@ -169,13 +171,15 @@ def pci(doc):
         src_dict["pci-tx"] = [
             pynvml.nvmlDeviceGetPcieThroughput(
                 gpu_handles[i], pynvml.NVML_PCIE_UTIL_TX_BYTES
-            ) * 1024.0
+            )
+            * 1024.0
             for i in range(ngpus)
         ]
         src_dict["pci-rx"] = [
             pynvml.nvmlDeviceGetPcieThroughput(
                 gpu_handles[i], pynvml.NVML_PCIE_UTIL_RX_BYTES
-            ) * 1024.0
+            )
+            * 1024.0
             for i in range(ngpus)
         ]
         source.data.update(src_dict)
@@ -307,10 +311,12 @@ def nvlink(doc):
             for i in range(ngpus)
         ]
         src_dict["count-tx"] = [
-            max(a - b, 0.) * 5.0 for (a, b) in zip(nvlink_state["tx"], nvlink_state["tx-ref"])
+            max(a - b, 0.0) * 5.0
+            for (a, b) in zip(nvlink_state["tx"], nvlink_state["tx-ref"])
         ]
         src_dict["count-rx"] = [
-            max(a - b, 0.) * 5.0 for (a, b) in zip(nvlink_state["rx"], nvlink_state["rx-ref"])
+            max(a - b, 0.0) * 5.0
+            for (a, b) in zip(nvlink_state["rx"], nvlink_state["rx-ref"])
         ]
 
         source.data.update(src_dict)
@@ -371,9 +377,7 @@ def nvlink_timeline(doc):
     rx_fig.yaxis.formatter = NumeralTickFormatter(format="0.0 b")
 
     doc.title = "NVLink Throughput Timeline"
-    doc.add_root(
-        column(tx_fig, rx_fig, sizing_mode="stretch_both")
-    )
+    doc.add_root(column(tx_fig, rx_fig, sizing_mode="stretch_both"))
 
     counter = 1
     nlinks = pynvml.NVML_NVLINK_MAX_LINKS
@@ -436,11 +440,13 @@ def nvlink_timeline(doc):
             for i in range(ngpus)
         ]
         tx_diff = [
-            max(a - b, 0.) * 5.0 for (a, b) in zip(nvlink_state["tx"], nvlink_state["tx-ref"])
+            max(a - b, 0.0) * 5.0
+            for (a, b) in zip(nvlink_state["tx"], nvlink_state["tx-ref"])
         ]
 
         rx_diff = [
-            max(a - b, 0.) * 5.0 for (a, b) in zip(nvlink_state["rx"], nvlink_state["rx-ref"])
+            max(a - b, 0.0) * 5.0
+            for (a, b) in zip(nvlink_state["rx"], nvlink_state["rx-ref"])
         ]
 
         for i in range(ngpus):

--- a/jupyterlab_nvdashboard/server.py
+++ b/jupyterlab_nvdashboard/server.py
@@ -11,7 +11,9 @@ routes = {
     "/GPU-Utilization": apps.gpu.gpu,
     "/GPU-Memory": apps.gpu.gpu_mem,
     "/GPU-Resources": apps.gpu.gpu_resource_timeline,
-    "/PCI-Throughput": apps.gpu.pci,
+    "/PCIe-Throughput": apps.gpu.pci,
+    "/NVLink-Throughput": apps.gpu.nvlink,
+    "/NVLink-Timeline": apps.gpu.nvlink_timeline,
     # "/CPU-Utilization": apps.cpu.cpu,
     "/Machine-Resources": apps.cpu.resource_timeline,
 }


### PR DESCRIPTION
These changes add "NVLink Throughput" and "NVLink Timeline" dashboares.   This addresses [#13](https://github.com/jacobtomlinson/jupyterlab-nvdashboard/issues/13), but requires pynvml 8.0.2+ (both conda and PyPI packages are available).

**Example** (deep learning training on 2-GPUs):

![Screen Shot 2019-08-20 at 1 14 54 PM](https://user-images.githubusercontent.com/20461013/63374367-493bcf80-c34f-11e9-9ba0-09e27902bf9b.png)


**Note 1**:  The "NVLink Throughput" axis range is set to the theoretical maximum for a single GPU (which can be quite large).  The "NVLink Timeline" axis, however, is adaptive.

**Note 2**:  The formatting/naming of the existing dashboards was also modfied a bit.  For example, I am changing "PCI" to "PCIe", and using consistent "Byte" formatting for labels/titles.